### PR TITLE
Allow setting ollama host in ENVIRONMENT

### DIFF
--- a/ENVIRONMENT
+++ b/ENVIRONMENT
@@ -1,4 +1,15 @@
 
+
+##########################################################################
+#
+# OLLAMA_HOST
+# Set this variable to use a remote ollama for prompt enhancement
+# If not specified, the default ollama host and port will be used.
+# (localhost:11434)
+#
+##########################################################################
+OLLAMA_HOST=
+
 ##########################################################################
 #
 # PINOKIO_SHARE_CLOUDFLARE


### PR DESCRIPTION
MFLUX-WEBUI has prompt enhancement with ollama built-in.
This adds "OLLAMA_HOST" to the environment to allow the use of a remote ollama instance.